### PR TITLE
Fixed issue where subjects were empty on content with >255 characters

### DIFF
--- a/src/Monolog/Handlers/MailableHandler.php
+++ b/src/Monolog/Handlers/MailableHandler.php
@@ -49,7 +49,12 @@ class MailableHandler extends MailHandler
      */
     protected function setSubject(array $records)
     {
-        $this->mailable->subject($this->subjectFormatter->format($this->getHighestRecord($records)));
+        $formatted = $this->subjectFormatter->format($this->getHighestRecord($records));
+
+        if (strlen($formatted) > 255)
+            $formatted = substr($formatted, 0, 252) . '...';
+
+        $this->mailable->subject($formatted);
     }
 
     /**

--- a/src/Monolog/Handlers/MailableHandler.php
+++ b/src/Monolog/Handlers/MailableHandler.php
@@ -6,6 +6,7 @@ use Illuminate\Mail\Mailable;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\MailHandler;
 use Monolog\Logger;
+use Illuminate\Support\Str;
 
 class MailableHandler extends MailHandler
 {
@@ -49,10 +50,7 @@ class MailableHandler extends MailHandler
      */
     protected function setSubject(array $records)
     {
-        $formatted = $this->subjectFormatter->format($this->getHighestRecord($records));
-
-        if (strlen($formatted) > 255)
-            $formatted = substr($formatted, 0, 252) . '...';
+        $formatted = Str::limit($this->subjectFormatter->format($this->getHighestRecord($records)), 252);
 
         $this->mailable->subject($formatted);
     }


### PR DESCRIPTION
We had following issue:

- We created a log entry with a content of over 255 characters.
- The E-Mail was sent, but the subject was empty.
- Fixed the issue by truncating the subject after the limit has been reached

https://stackoverflow.com/questions/1592291/what-is-the-email-subject-length-limit#comment5147138_1592291